### PR TITLE
Order dotnet auth middelware correctly

### DIFF
--- a/backend/MiniTwit-API/Program.cs
+++ b/backend/MiniTwit-API/Program.cs
@@ -83,13 +83,13 @@ app.UseRouting();
 app.UseHttpMetrics();
 app.UseMetricServer();
 
-app.UseEndpoints(endpoints =>
-    endpoints.MapMetrics()
-);
-
 app.UseAuthentication();
 
 app.UseAuthorization();
+
+app.UseEndpoints(endpoints =>
+    endpoints.MapMetrics()
+);
 
 app.MapControllers();
 


### PR DESCRIPTION
Turns out the order matters, when calling `app.UseAuthentication` and `app.UseAuthorization` and that they should be in between `app.UseRouting` and `app.UseEndpoints`